### PR TITLE
Add isChrome method

### DIFF
--- a/browser-detection.js
+++ b/browser-detection.js
@@ -1,12 +1,14 @@
 'use strict';
 
 var isAndroid = require('./is-android');
+var isChrome = require('./is-chrome');
 var isIe9 = require('./is-ie9');
 var isIos = require('./is-ios');
 var supportsPopups = require('./supports-popups');
 
 module.exports = {
   isAndroid: isAndroid,
+  isChrome: isChrome,
   isIe9: isIe9,
   isIos: isIos,
   supportsPopups: supportsPopups

--- a/is-chrome.js
+++ b/is-chrome.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function isChrome(ua) {
+  ua = ua || navigator.userAgent;
+  return ua.indexOf('Chrome') !== -1 || ua.indexOf('CriOS') !== -1;
+};

--- a/test/browser-detection.js
+++ b/test/browser-detection.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var browserDetection = require('../browser-detection');
+
+describe('browserDetection', function () {
+  it('includes a prop for each js file in the root directory', function () {
+    var functions = Object.keys(browserDetection);
+    var files = fs.readdirSync('./');
+    var jsFileNames = files.filter(function (file) {
+      return path.extname(file) === '.js' &&
+        file !== 'browser-detection.js';
+    });
+    var jsFiles = jsFileNames.map(function (file) {
+      return require('../' + file);
+    });
+
+    expect(jsFiles.length).to.be.greaterThan(0);
+
+    jsFiles.forEach(function (module) {
+      var found = functions.find(function (prop) {
+        return module === browserDetection[prop];
+      });
+
+      if (!found) {
+        throw new Error(module + ' was not found on browserDetection');
+      }
+    });
+  });
+});

--- a/test/is-chrome.js
+++ b/test/is-chrome.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var isChrome = require('../is-chrome');
+var AGENTS = require('./helpers/user-agents');
+
+describe('isChrome', function () {
+  it('false when IE9', function () {
+    expect(isChrome(AGENTS.ie9)).to.equal(false);
+  });
+
+  it('returns true for iOS Chrome', function () {
+    expect(isChrome(AGENTS.iPhoneUnsupportedChrome)).to.equal(true);
+    expect(isChrome(AGENTS.iPhoneSupportedChrome)).to.equal(true);
+  });
+
+  it('returns true for Android Chrome', function () {
+    expect(isChrome(AGENTS.androidPhoneChrome)).to.equal(true);
+  });
+
+  it('returns true for desktop Chrome', function () {
+    expect(isChrome(AGENTS.pcChrome_27)).to.equal(true);
+    expect(isChrome(AGENTS.pcChrome_41)).to.equal(true);
+  });
+});
+


### PR DESCRIPTION
For use with the restricted input. See https://github.com/braintree/restricted-input/pull/35/files#r110049705

This logic includes a check for iOS Chrome, which is a little different from the current implementation in restricted-input, but as we only use it to determine if a device is Android Chrome, it shouldn't make a difference.