### PR TITLE
fix: correct isIosSafari logic to handle Facebook webview

### DIFF
--- a/src/__tests__/helpers/user-agents.json
+++ b/src/__tests__/helpers/user-agents.json
@@ -40,6 +40,7 @@
   "iPhoneGoogleSearchAppWebview": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) GSA/16.0.124986583 Mobile/13F69 Safari/600.1.4",
   "iPhoneOperaWebview": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 OPT/2.5.1",
   "iPhoneDuckDuckGo": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.4 Mobile/15E148 DuckDuckGo/7 Safari/605.1.15",
+  "iPhoneFacebookWebview": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LightSpeed [FBAN/MessengerLiteForiOS;FBAV/304.0.0.36.119;FBBV/277977129;FBDV/iPhone10,4;FBMD/iPhone;FBSN/iOS;FBSV/14.4.1;FBSS/2;FBCR/;FBID/phone;FBLC/en;FBOP/0]",
   "linuxFirefox": "Mozilla/5.0 (Maemo; Linux armv7l; rv:10.0) Gecko/20100101 Firefox/10.0 Fennec/10.0",
   "linuxOpera": "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16",
   "linuxSilk": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.3.4 like Chrome/89.0.4389.105 Safari/537.36",

--- a/src/__tests__/is-ios-safari.ts
+++ b/src/__tests__/is-ios-safari.ts
@@ -19,6 +19,10 @@ describe("isIosSafari", () => {
     expect(isIosSafari(AGENTS.iPhoneSupportedChrome)).toBe(false);
   });
 
+  it("returns false for iOS Facebook", () => {
+    expect(isIosSafari(AGENTS.iPhoneFacebookWebview)).toBe(false);
+  });
+
   it("returns false for iOS Firefox", () => {
     expect(isIosSafari(AGENTS.iPhoneFirefox)).toBe(false);
     expect(isIosSafari(AGENTS.iPadFirefox)).toBe(false);

--- a/src/is-ios-safari.ts
+++ b/src/is-ios-safari.ts
@@ -11,6 +11,10 @@ export = function isIosSafari(ua?: string): boolean {
   ua = ua || window.navigator.userAgent;
 
   return (
-    isIos(ua) && isWebkit(ua) && ua.indexOf("CriOS") === -1 && !isIosFirefox(ua)
+    isIos(ua) &&
+    isWebkit(ua) &&
+    ua.indexOf("CriOS") === -1 &&
+    !isIosFirefox(ua) &&
+    ua.indexOf("FBAN") === -1
   );
 };


### PR DESCRIPTION
Apologies for the delay on this one.  Fixes https://github.com/braintree/browser-detection/issues/26.

Let me know if there's anything I need to change or feel free to take over the PR.