### PR TITLE
Updating is-ios to account for new user agents and creating is-ipados

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Unreleased
 
 - Remove window.safari object validation from iOS webview.
+- Update `is-ios` to account for user agent behavior on newer iPads
+- Add `is-ipados` method
 
 # 1.13.0 (2022-07-14)
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ browserDetection.isIosSafari();
 browserDetection.isIosWebview();
 browserDetection.isIosUIWebview();
 browserDetection.isIosWKWebview();
+browserDetection.isIpadOS();
 browserDetection.isMobileFirefox();
 browserDetection.isOpera();
 browserDetection.isSamsungBrowser();
@@ -53,6 +54,7 @@ const isIosSafari = require("browser-detection/is-ios-safari");
 const isIosWebview = require("browser-detection/is-ios-webview");
 const isIosUIWebview = require("browser-detection/is-ios-uiwebview");
 const isIosWKWebview = require("browser-detection/is-ios-wkwebview");
+const isIpadOS = require("browser-detection/is-ipados");
 const isMobileFirefox = require("browser-detection/is-mobile-firefox");
 const isOpera = require("browser-detection/is-opera");
 const isSamsungBrowser = require("browser-detection/is-samsung");
@@ -66,4 +68,16 @@ const supportsPopups = require("browser-detection/supports-popups");
 
 ```sh
 npm test
+```
+### Notes on isIpadOs
+
+isIpadOS is a new option for browser detection, and is also included in isIos. isIos defaults to checking for iPads to maintain consistent behavior with how it acted in the past. If `checkIpadOS` is set to false, then it will only check for older gen iPads and current iOS
+```js
+const browserDetection = require("browser-detection");
+const ua = window.navigator.userAgent;
+// assume ua is from iPadOs 13 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15"
+browserDetection.isIos(ua);
+// will return true
+browserDetection.isIos(ua, false);
+// will return false
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npm test
 ```
 ### Notes on isIpadOs
 
-isIpadOS is a new option for browser detection, and is also included in isIos. isIos defaults to checking for iPads to maintain consistent behavior with how it acted in the past. If `checkIpadOS` is set to false, then it will only check for older gen iPads and current iOS
+`isIpadOS` is a new option for browser detection, and is also included in isIos. isIos defaults to checking for iPads to maintain consistent behavior with how it acted in the past. If `checkIpadOS` is set to false, then it will only check for older gen iPads and current iOS
 ```js
 const browserDetection = require("browser-detection");
 const ua = window.navigator.userAgent;

--- a/is-ipados.js
+++ b/is-ipados.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/is-ipados");

--- a/src/__tests__/helpers/user-agents.json
+++ b/src/__tests__/helpers/user-agents.json
@@ -29,6 +29,7 @@
   "iPadFirefox": "Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4",
   "iPadWebview": "Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/98176",
   "iPadChromeLowercase": "Mozilla/5.0 (ipad Windows; U; Windows NT 6.1; en-US) AppleWebKit/534.6 (KHTML, like Gecko) Chrome/7.0.498.0 Safari/534.6",
+  "iPad13_Safari": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15",
   "iPodFirefox": "Mozilla/5.0 (iPod touch; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4",
   "iPodSafari": "Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/3A101a Safari/419.3",
   "iPodWebview": "Mozilla/5.0 (iPod; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/3A101a",

--- a/src/__tests__/is-ios.ts
+++ b/src/__tests__/is-ios.ts
@@ -4,11 +4,19 @@ const AGENTS: {
   [key: string]: string;
 } = require("./helpers/user-agents.json");
 
+const DOCUMENT_OBJECT = {
+  ontouchend: null,
+};
+
 describe("isIos", () => {
-  it("returns true for an iPad", () => {
+  it("returns true for an iPad version lower than iPad OS v13", () => {
     expect(isIos(AGENTS.iPad3_2Safari)).toBe(true);
     expect(isIos(AGENTS.iPad5_1Safari)).toBe(true);
     expect(isIos(AGENTS.iPad9_3Safari)).toBe(true);
+  });
+
+  it("returns true for an iPad version greater than iPad OS v13", () => {
+    expect(isIos(AGENTS.iPad13_Safari, true, DOCUMENT_OBJECT)).toBe(true);
   });
 
   it("returns true for an iPod", () => {
@@ -41,5 +49,9 @@ describe("isIos", () => {
         expect(isIos(ua)).toBe(false);
       }
     }
+  });
+
+  it("return false for for iPad OS v13 when passing false for checkiPadOS", () => {
+    expect(isIos(AGENTS.iPad13_Safari, false, DOCUMENT_OBJECT)).toBe(false);
   });
 });

--- a/src/__tests__/is-ipados.ts
+++ b/src/__tests__/is-ipados.ts
@@ -1,0 +1,45 @@
+import isIpadOS = require("../is-ipados");
+
+const AGENTS: {
+  [key: string]: string;
+} = require("./helpers/user-agents.json");
+
+const DOCUMENT_OBJECT = {
+  ontouchend: null,
+};
+
+const DOCUMENT_OBJECT_EMPTY = {};
+
+describe("isIpadOS", () => {
+  it("returns true for an iPad", () => {
+    expect(isIpadOS(AGENTS.iPad3_2Safari, DOCUMENT_OBJECT)).toBe(true);
+    expect(isIpadOS(AGENTS.iPad5_1Safari, DOCUMENT_OBJECT)).toBe(true);
+    expect(isIpadOS(AGENTS.iPad9_3Safari, DOCUMENT_OBJECT)).toBe(true);
+    expect(isIpadOS(AGENTS.iPad13_Safari, DOCUMENT_OBJECT)).toBe(true);
+  });
+
+  it("returns false when ontouchend is undefined", () => {
+    expect(isIpadOS(AGENTS.iPad3_2Safari, DOCUMENT_OBJECT_EMPTY)).toBe(false);
+    expect(isIpadOS(AGENTS.iPad5_1Safari, DOCUMENT_OBJECT_EMPTY)).toBe(false);
+    expect(isIpadOS(AGENTS.iPad9_3Safari, DOCUMENT_OBJECT_EMPTY)).toBe(false);
+    expect(isIpadOS(AGENTS.iPad13_Safari, DOCUMENT_OBJECT_EMPTY)).toBe(false);
+  });
+
+  it("returns true for ipad", () => {
+    expect(isIpadOS(AGENTS.iPadChromeLowercase, DOCUMENT_OBJECT)).toBe(true);
+  });
+
+  it("returns false for non-iOS browsers", () => {
+    let key, ua;
+
+    for (key in AGENTS) {
+      if (!AGENTS.hasOwnProperty(key)) {
+        continue;
+      }
+      if (!/iPhone|iPad|iPod/.test(key)) {
+        ua = AGENTS[key];
+        expect(isIpadOS(ua)).toBe(false);
+      }
+    }
+  });
+});

--- a/src/browser-detection.ts
+++ b/src/browser-detection.ts
@@ -15,6 +15,7 @@ import isIosSafari = require("./is-ios-safari");
 import isIosUIWebview = require("./is-ios-uiwebview");
 import isIosWebview = require("./is-ios-webview");
 import isIosWKWebview = require("./is-ios-wkwebview");
+import isIpadOS = require("./is-ipados");
 import isMobileFirefox = require("./is-mobile-firefox");
 import isOpera = require("./is-opera");
 import isSamsungBrowser = require("./is-samsung");
@@ -41,6 +42,7 @@ export {
   isIosUIWebview,
   isIosWebview,
   isIosWKWebview,
+  isIpadOS,
   isMobileFirefox,
   isOpera,
   isSamsungBrowser,

--- a/src/is-ios.ts
+++ b/src/is-ios.ts
@@ -1,5 +1,11 @@
-export = function isIos(ua?: string): boolean {
-  ua = ua || window.navigator.userAgent;
+import isIpadOS = require("./is-ipados");
 
-  return /iPhone|iPod|iPad/i.test(ua);
+export = function isIos(
+  ua?: string,
+  checkIpadOS = true,
+  document?: object
+): boolean {
+  ua = ua || window.navigator.userAgent;
+  const iOsTest = /iPhone|iPod|iPad/i.test(ua);
+  return checkIpadOS ? iOsTest || isIpadOS(ua, document) : iOsTest;
 };

--- a/src/is-ipados.ts
+++ b/src/is-ipados.ts
@@ -1,0 +1,8 @@
+export = function isIpadOS(ua?: string, document?: object): boolean {
+  ua = ua || window.navigator.userAgent;
+  document = document || window.document;
+
+  // "ontouchend" is used to determine if a browser is on an iPad, otherwise
+  // user-agents for iPadOS behave/identify as a desktop browser
+  return /Mac|iPad/i.test(ua) && "ontouchend" in document;
+};


### PR DESCRIPTION
### Summary

- Updates isIos to properly identify newer iPads
- Created new `isIpadOS` to allow for direct checking for iPads

### Checklist

- [x] Added a changelog entry

### Authors

> List GitHub usernames for everyone who contributed to this pull request.

- @SancSalix 
- @mchoun