### PR TITLE
is-safari module for desktop Safari detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Browser Detection - Release Notes
 
+# Unreleased
+
+- Add `is-safari` method ([#48](https://github.com/braintree/browser-detection/issues/48))
+
 # 1.16.0 (2023-05-08)
 
 - Remove window.safari object validation from iOS webview.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Unreleased
 
-- Add `is-safari` method ([#48](https://github.com/braintree/browser-detection/issues/48))
+- Add `is-safari` method for desktop Safari detection ([#48](https://github.com/braintree/browser-detection/issues/48))
 
 # 1.16.0 (2023-05-08)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ browserDetection.isChrome();
 browserDetection.isDuckDuckGo();
 browserDetection.isEdge();
 browserDetection.isFirefox();
+browserDetection.isSafari();
 browserDetection.isIe();
 browserDetection.isIe9();
 browserDetection.isIe10();
@@ -43,6 +44,7 @@ const isChrome = require("browser-detection/is-chrome");
 const isDuckDuckGo = require("browser-detection/is-duckduckgo");
 const isEdge = require("browser-detection/is-edge");
 const isFirefox = require("browser-detection/is-firefox");
+const isSafari = require("browser-detection/is-safari");
 const isIe = require("browser-detection/is-ie");
 const isIe9 = require("browser-detection/is-ie9");
 const isIe10 = require("browser-detection/is-ie10");
@@ -83,3 +85,7 @@ browserDetection.isIos(ua);
 browserDetection.isIos(ua, false);
 // will return false
 ```
+
+### Notes on Safari
+
+`is-safari` is used for _desktop_ Safari detection, if you are trying to detect an iOS version of Safari, use `is-ios-safari`.

--- a/is-safari.js
+++ b/is-safari.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/is-safari");

--- a/src/__tests__/is-safari.test.ts
+++ b/src/__tests__/is-safari.test.ts
@@ -1,0 +1,65 @@
+import isSafari from "../is-safari";
+
+const AGENTS: {
+  [key: string]: string;
+} = require("./helpers/user-agents.json");
+
+describe("isSafari", () => {
+  it("returns true when safari", () => {
+    expect(isSafari(AGENTS.macSafari7_0_2)).toBe(true);
+    expect(isSafari(AGENTS.pcSafari5_1)).toBe(true);
+  });
+
+  it("returns false when iOS safari", () => {
+    expect(isSafari(AGENTS.iPhone_9_3_1Safari)).toBe(false);
+    expect(isSafari(AGENTS.iPhone_3_2Safari)).toBe(false);
+    expect(isSafari(AGENTS.iPad3_2Safari)).toBe(false);
+    expect(isSafari(AGENTS.iPad5_1Safari)).toBe(false);
+    expect(isSafari(AGENTS.iPad9_3Safari)).toBe(false);
+    expect(isSafari(AGENTS.iPodSafari)).toBe(false);
+  });
+
+  it("returns false for iOS Facebook", () => {
+    expect(isSafari(AGENTS.iPhoneFacebookWebview)).toBe(false);
+  });
+
+  it("returns false when chrome", () => {
+    expect(isSafari(AGENTS.pcChrome_27)).toBe(false);
+    expect(isSafari(AGENTS.pcChrome_41)).toBe(false);
+    expect(isSafari(AGENTS.pcChrome_60)).toBe(false);
+    expect(isSafari(AGENTS.pcChrome_61)).toBe(false);
+  });
+
+  it("returns false when firefox", () => {
+    expect(isSafari(AGENTS.pcFirefox)).toBe(false);
+    expect(isSafari(AGENTS.macFirefox)).toBe(false);
+    expect(isSafari(AGENTS.linuxFirefox)).toBe(false);
+  });
+
+  it("returns false when opera", () => {
+    expect(isSafari(AGENTS.pcOpera)).toBe(false);
+    expect(isSafari(AGENTS.macOpera)).toBe(false);
+    expect(isSafari(AGENTS.linuxOpera)).toBe(false);
+  });
+
+  it("returns false when IE", () => {
+    expect(isSafari(AGENTS.ie7)).toBe(false);
+    expect(isSafari(AGENTS.ie8)).toBe(false);
+    expect(isSafari(AGENTS.ie9)).toBe(false);
+    expect(isSafari(AGENTS.ie10)).toBe(false);
+    expect(isSafari(AGENTS.ie11)).toBe(false);
+  });
+
+  it("returns false when edge", () => {
+    expect(isSafari(AGENTS.edge12)).toBe(false);
+    expect(isSafari(AGENTS.edge13)).toBe(false);
+  });
+
+  it("returns false for all android browsers", () => {
+    Object.keys(AGENTS).forEach((key) => {
+      if (/Android/i.test(key)) {
+        expect(isSafari(AGENTS[key])).toBe(false);
+      }
+    });
+  });
+});

--- a/src/__tests__/is-safari.test.ts
+++ b/src/__tests__/is-safari.test.ts
@@ -5,7 +5,7 @@ const AGENTS: {
 } = require("./helpers/user-agents.json");
 
 describe("isSafari", () => {
-  it("returns true when safari", () => {
+  it("returns true when desktop safari", () => {
     expect(isSafari(AGENTS.macSafari7_0_2)).toBe(true);
     expect(isSafari(AGENTS.pcSafari5_1)).toBe(true);
   });
@@ -23,34 +23,26 @@ describe("isSafari", () => {
     expect(isSafari(AGENTS.iPhoneFacebookWebview)).toBe(false);
   });
 
-  it("returns false when chrome", () => {
+  it("returns false when desktop chrome", () => {
     expect(isSafari(AGENTS.pcChrome_27)).toBe(false);
     expect(isSafari(AGENTS.pcChrome_41)).toBe(false);
     expect(isSafari(AGENTS.pcChrome_60)).toBe(false);
     expect(isSafari(AGENTS.pcChrome_61)).toBe(false);
   });
 
-  it("returns false when firefox", () => {
+  it("returns false when desktop firefox", () => {
     expect(isSafari(AGENTS.pcFirefox)).toBe(false);
     expect(isSafari(AGENTS.macFirefox)).toBe(false);
     expect(isSafari(AGENTS.linuxFirefox)).toBe(false);
   });
 
-  it("returns false when opera", () => {
+  it("returns false when desktop opera", () => {
     expect(isSafari(AGENTS.pcOpera)).toBe(false);
     expect(isSafari(AGENTS.macOpera)).toBe(false);
     expect(isSafari(AGENTS.linuxOpera)).toBe(false);
   });
 
-  it("returns false when IE", () => {
-    expect(isSafari(AGENTS.ie7)).toBe(false);
-    expect(isSafari(AGENTS.ie8)).toBe(false);
-    expect(isSafari(AGENTS.ie9)).toBe(false);
-    expect(isSafari(AGENTS.ie10)).toBe(false);
-    expect(isSafari(AGENTS.ie11)).toBe(false);
-  });
-
-  it("returns false when edge", () => {
+  it("returns false when desktop edge", () => {
     expect(isSafari(AGENTS.edge12)).toBe(false);
     expect(isSafari(AGENTS.edge13)).toBe(false);
   });

--- a/src/browser-detection.ts
+++ b/src/browser-detection.ts
@@ -11,6 +11,7 @@ import isFirefox from "./is-firefox";
 import isIos from "./is-ios";
 import isIosFirefox from "./is-ios-firefox";
 import isIosGoogleSearchApp from "./is-ios-google-search-app";
+import isSafari from "./is-safari";
 import isIosSafari from "./is-ios-safari";
 import isIosUIWebview from "./is-ios-uiwebview";
 import isIosWebview from "./is-ios-webview";
@@ -38,6 +39,7 @@ export {
   isIos,
   isIosFirefox,
   isIosGoogleSearchApp,
+  isSafari,
   isIosSafari,
   isIosUIWebview,
   isIosWebview,

--- a/src/is-safari.ts
+++ b/src/is-safari.ts
@@ -1,0 +1,11 @@
+function isSafari(ua?: string): boolean {
+  ua = ua || window.navigator.userAgent;
+
+  return (
+    /^Mozilla\/5\.0.*Safari\//.test(ua) &&
+    !/(iPhone|iPad|iPod|Android|SM-)/i.test(ua) &&
+    !/Chrome|CriOS|FxiOS|OPiOS|mercury/i.test(ua)
+  );
+}
+
+export default isSafari;


### PR DESCRIPTION
## Quick PR Summary
* Add `is-safari` module for desktop Safari detection ([#48](https://github.com/braintree/browser-detection/issues/48))

For internal tracking, DTBTSDK-2780

### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @oscarleonnogales 