### PR TITLE
test: improve unit test branch coverage to >80%

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
   "homepage": "https://github.com/braintree/browser-detection#readme",
   "jest": {
     "testPathIgnorePatterns": [
-      "<rootDir>/src/__tests__/playwright/*"
+      "<rootDir>/src/__tests__/playwright/*",
+      "<rootDir>/src/__tests__/helpers/*"
     ],
     "testEnvironment": "jsdom",
     "preset": "ts-jest",
@@ -77,7 +78,8 @@
     "collectCoverage": true,
     "collectCoverageFrom": [
       "src/**/*.ts",
-      "!src/__tests__/**"
+      "!src/__tests__/**",
+      "!src/browser-detection.ts"
     ],
     "coverageThreshold": {
       "global": {

--- a/src/__tests__/helpers/restore-window.ts
+++ b/src/__tests__/helpers/restore-window.ts
@@ -1,0 +1,31 @@
+/**
+ * Captures the jsdom default values of window properties that unit tests may
+ * mutate via Object.defineProperty, and exposes a helper that restores them
+ * in an afterEach hook. Call this at the top of any describe block whose
+ * tests modify window.navigator.userAgent or window.statusbar, so that
+ * mutations don't leak into subsequent tests in the same file.
+ *
+ * Usage:
+ *   import { restoreWindow } from "../helpers/restore-window";
+ *   describe("myModule", () => {
+ *     restoreWindow();
+ *     ...
+ *   });
+ */
+
+const DEFAULT_UA = window.navigator.userAgent;
+
+export function restoreWindow(): void {
+  afterEach(() => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: DEFAULT_UA,
+      configurable: true,
+    });
+
+    // window.statusbar does not exist in jsdom — delete it if a test added it.
+    delete (window as unknown as Record<string, unknown>).statusbar;
+
+    // window.document.ontouchend does not exist in jsdom — delete it if a test added it.
+    delete (window.document as unknown as Record<string, unknown>).ontouchend;
+  });
+}

--- a/src/__tests__/unit/browser-detection.ts
+++ b/src/__tests__/unit/browser-detection.ts
@@ -1,6 +1,15 @@
 import fs = require("fs");
 import path = require("path");
 
+// This test intentionally imports from the compiled dist/ artifact rather than the TypeScript
+// source. Its purpose is publish-integrity: it verifies that each root-level .js shim
+// (e.g. is-android.js → dist/is-android) is also exposed as a named export on the main
+// dist/browser-detection bundle, matching the tree-shaking contract for package consumers.
+//
+// Because this test never loads src/browser-detection.ts through ts-jest, Istanbul cannot
+// instrument it — so that file is excluded from collectCoverageFrom in package.json.
+// src/browser-detection.ts is a pure re-export barrel with no logic or branches, so there
+// is no value in a separate TypeScript-source-level test for it.
 const browserDetection: {
   [key: string]: (ua: string) => boolean;
 } = require("../../../dist/browser-detection");

--- a/src/__tests__/unit/is-android.ts
+++ b/src/__tests__/unit/is-android.ts
@@ -1,10 +1,13 @@
 import isAndroid = require("../../is-android");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isAndroid", () => {
+  restoreWindow();
+
   it("returns true for Android browsers", () => {
     expect(isAndroid(AGENTS.androidOperaMini)).toBe(true);
     expect(isAndroid(AGENTS.androidPhoneFirefox)).toBe(true);
@@ -19,6 +22,14 @@ describe("isAndroid", () => {
     expect(isAndroid(AGENTS.androidChromeWebviewKitKatLollipop)).toBe(true);
     expect(isAndroid(AGENTS.androidChromeWebviewLollipopAndAbove)).toBe(true);
     expect(isAndroid(AGENTS.androidPhoneChrome_101FacebookWebview)).toBe(true);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.androidPhoneChrome,
+      configurable: true,
+    });
+    expect(isAndroid()).toBe(true);
   });
 
   it("returns false for non-Android browsers", () => {

--- a/src/__tests__/unit/is-chrome-os.ts
+++ b/src/__tests__/unit/is-chrome-os.ts
@@ -1,10 +1,13 @@
 import isChromeOS = require("../../is-chrome-os");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isChromeOS", () => {
+  restoreWindow();
+
   it("returns true for ChromeOS Chrome", () => {
     expect(isChromeOS(AGENTS.chromeOsChrome)).toBe(true);
   });
@@ -14,6 +17,14 @@ describe("isChromeOS", () => {
     // questionably functional Android port. For example Firefox & Brave
     // have Android user agents, and Edge installs but doesn't actually
     // work.
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.chromeOsChrome,
+      configurable: true,
+    });
+    expect(isChromeOS()).toBe(true);
   });
 
   it("returns false for non-ChromeOS browsers", () => {

--- a/src/__tests__/unit/is-chrome.ts
+++ b/src/__tests__/unit/is-chrome.ts
@@ -1,10 +1,13 @@
 import isChrome = require("../../is-chrome");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isChrome", () => {
+  restoreWindow();
+
   it("false when IE9", () => {
     expect(isChrome(AGENTS.ie9)).toBe(false);
   });
@@ -33,6 +36,14 @@ describe("isChrome", () => {
 
   it("returns false for old Android Chromium-based WebViews", () => {
     expect(isChrome(AGENTS.androidChromeWebviewOld)).toBe(false);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.androidPhoneChrome,
+      configurable: true,
+    });
+    expect(isChrome()).toBe(true);
   });
 
   it("returns false for other browsers", () => {

--- a/src/__tests__/unit/is-duckduckgo.ts
+++ b/src/__tests__/unit/is-duckduckgo.ts
@@ -1,16 +1,27 @@
 import isDuckDuckGo = require("../../is-duckduckgo");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isDuckDuckGo", () => {
+  restoreWindow();
+
   it("returns true for android DuckDuckGo", () => {
     expect(isDuckDuckGo(AGENTS.androidDuckDuckGo)).toBe(true);
   });
 
   it("returns true for iOS DuckDuckGo", () => {
     expect(isDuckDuckGo(AGENTS.iPhoneDuckDuckGo)).toBe(true);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.androidDuckDuckGo,
+      configurable: true,
+    });
+    expect(isDuckDuckGo()).toBe(true);
   });
 
   it("returns false for all other browsers", () => {

--- a/src/__tests__/unit/is-edge.ts
+++ b/src/__tests__/unit/is-edge.ts
@@ -1,10 +1,13 @@
 import isEdge = require("../../is-edge");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isEdge", () => {
+  restoreWindow();
+
   it("returns false when chrome", () => {
     expect(isEdge(AGENTS.pcChrome_41)).toBe(false);
   });
@@ -31,5 +34,13 @@ describe("isEdge", () => {
 
   it("returns true when Edge 103", () => {
     expect(isEdge(AGENTS.edge103)).toBe(true);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.edge103,
+      configurable: true,
+    });
+    expect(isEdge()).toBe(true);
   });
 });

--- a/src/__tests__/unit/is-firefox.ts
+++ b/src/__tests__/unit/is-firefox.ts
@@ -1,10 +1,13 @@
 import isFirefox = require("../../is-firefox");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isFirefox", () => {
+  restoreWindow();
+
   it("returns true for android phone Firefox", () => {
     expect(isFirefox(AGENTS.androidPhoneFirefox)).toBe(true);
   });
@@ -15,6 +18,14 @@ describe("isFirefox", () => {
 
   it("returns false for ios Firefox (simply a safari webview)", () => {
     expect(isFirefox(AGENTS.iPhoneFirefox)).toBe(false);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.androidPhoneFirefox,
+      configurable: true,
+    });
+    expect(isFirefox()).toBe(true);
   });
 
   it("returns true for desktop Firefox", () => {

--- a/src/__tests__/unit/is-ie.ts
+++ b/src/__tests__/unit/is-ie.ts
@@ -1,10 +1,13 @@
 import isIe = require("../../is-ie");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isIe", () => {
+  restoreWindow();
+
   it("returns false when chrome", () => {
     expect(isIe(AGENTS.pcChrome_41)).toBe(false);
   });
@@ -35,5 +38,13 @@ describe("isIe", () => {
 
   it("returns true when IE11", () => {
     expect(isIe(AGENTS.ie11)).toBe(true);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.ie11,
+      configurable: true,
+    });
+    expect(isIe()).toBe(true);
   });
 });

--- a/src/__tests__/unit/is-ie10.ts
+++ b/src/__tests__/unit/is-ie10.ts
@@ -1,10 +1,13 @@
 import isIe10 = require("../../is-ie10");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isIe10", () => {
+  restoreWindow();
+
   it("false when chrome", () => {
     expect(isIe10(AGENTS.pcChrome_41)).toBe(false);
   });
@@ -15,5 +18,13 @@ describe("isIe10", () => {
 
   it("false when IE9", () => {
     expect(isIe10(AGENTS.ie9)).toBe(false);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.ie10,
+      configurable: true,
+    });
+    expect(isIe10()).toBe(true);
   });
 });

--- a/src/__tests__/unit/is-ie11.ts
+++ b/src/__tests__/unit/is-ie11.ts
@@ -1,10 +1,13 @@
 import isIe11 = require("../../is-ie11");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isIe11", () => {
+  restoreWindow();
+
   it("returns false when chrome", () => {
     expect(isIe11(AGENTS.pcChrome_41)).toBe(false);
   });
@@ -19,5 +22,13 @@ describe("isIe11", () => {
 
   it("returns false when IE10", () => {
     expect(isIe11(AGENTS.ie10)).toBe(false);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.ie11,
+      configurable: true,
+    });
+    expect(isIe11()).toBe(true);
   });
 });

--- a/src/__tests__/unit/is-ie9.ts
+++ b/src/__tests__/unit/is-ie9.ts
@@ -1,10 +1,13 @@
 import isIe9 = require("../../is-ie9");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isIe9", () => {
+  restoreWindow();
+
   it("false when chrome", () => {
     expect(isIe9(AGENTS.pcChrome_41)).toBe(false);
   });
@@ -15,5 +18,13 @@ describe("isIe9", () => {
 
   it("false when IE8", () => {
     expect(isIe9(AGENTS.ie8)).toBe(false);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.ie9,
+      configurable: true,
+    });
+    expect(isIe9()).toBe(true);
   });
 });

--- a/src/__tests__/unit/is-ios-firefox.ts
+++ b/src/__tests__/unit/is-ios-firefox.ts
@@ -1,10 +1,13 @@
 import isIosFirefox = require("../../is-ios-firefox");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isIosFirefox", () => {
+  restoreWindow();
+
   it("returns true for iPhone Firefox", () => {
     expect(isIosFirefox(AGENTS.iPhoneFirefox)).toBe(true);
   });
@@ -34,6 +37,14 @@ describe("isIosFirefox", () => {
         expect(isIosFirefox(ua)).toBe(false);
       }
     });
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.iPhoneFirefox,
+      configurable: true,
+    });
+    expect(isIosFirefox()).toBe(true);
   });
 
   it("returns false for all other browsers", () => {

--- a/src/__tests__/unit/is-ios-google-search-app.ts
+++ b/src/__tests__/unit/is-ios-google-search-app.ts
@@ -1,14 +1,25 @@
 import isIosGoogleSearchApp = require("../../is-ios-google-search-app");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isIosGoogleSearchApp", () => {
+  restoreWindow();
+
   it("returns true for iphone GoogleSearchApp", () => {
     expect(isIosGoogleSearchApp(AGENTS.iPhoneGoogleSearchAppWebview)).toBe(
       true,
     );
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.iPhoneGoogleSearchAppWebview,
+      configurable: true,
+    });
+    expect(isIosGoogleSearchApp()).toBe(true);
   });
 
   it("returns false for all other browsers", () => {

--- a/src/__tests__/unit/is-ios-safari.ts
+++ b/src/__tests__/unit/is-ios-safari.ts
@@ -1,10 +1,13 @@
 import isIosSafari = require("../../is-ios-safari");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isIosSafari", () => {
+  restoreWindow();
+
   it("returns true for iOS Safari", () => {
     expect(isIosSafari(AGENTS.iPhone_9_3_1Safari)).toBe(true);
     expect(isIosSafari(AGENTS.iPhone_3_2Safari)).toBe(true);
@@ -31,6 +34,14 @@ describe("isIosSafari", () => {
 
   it("returns false for Android Chrome", () => {
     expect(isIosSafari(AGENTS.androidPhoneChrome)).toBe(false);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.iPhone_9_3_1Safari,
+      configurable: true,
+    });
+    expect(isIosSafari()).toBe(true);
   });
 
   it("returns false for desktop Safari", () => {

--- a/src/__tests__/unit/is-ios-uiwebview.ts
+++ b/src/__tests__/unit/is-ios-uiwebview.ts
@@ -1,10 +1,13 @@
 import isIosUIWebview = require("../../is-ios-uiwebview");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isIosUIWebview", () => {
+  restoreWindow();
+
   it("returns true for iOS webviews when statusbar.visible is false", () => {
     expect(isIosUIWebview(AGENTS.iPadWebview, false)).toBe(true);
     expect(isIosUIWebview(AGENTS.iPodWebview, false)).toBe(true);
@@ -21,5 +24,13 @@ describe("isIosUIWebview", () => {
     expect(isIosUIWebview(AGENTS.iPhoneGoogleSearchAppWebview, true)).toBe(
       false,
     );
+  });
+
+  it("uses window.statusbar.visible when statusBarVisible is not provided", () => {
+    Object.defineProperty(window, "statusbar", {
+      value: { visible: false },
+      configurable: true,
+    });
+    expect(isIosUIWebview(AGENTS.iPhoneWebview)).toBe(true);
   });
 });

--- a/src/__tests__/unit/is-ios-webview.ts
+++ b/src/__tests__/unit/is-ios-webview.ts
@@ -1,10 +1,13 @@
 import isIosWebview = require("../../is-ios-webview");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isIosWebview", () => {
+  restoreWindow();
+
   it("returns true for iOS webviews", () => {
     let key, ua;
     for (key in AGENTS) {
@@ -60,6 +63,14 @@ describe("isIosWebview", () => {
         }
       }
     }
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.iPhoneWebview,
+      configurable: true,
+    });
+    expect(isIosWebview()).toBe(true);
   });
 
   it("returns true for Google Search App", () => {

--- a/src/__tests__/unit/is-ios-wkwebview.ts
+++ b/src/__tests__/unit/is-ios-wkwebview.ts
@@ -1,10 +1,13 @@
 import isIosWKWebview = require("../../is-ios-wkwebview");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isIosWKWebview", () => {
+  restoreWindow();
+
   let key, ua;
 
   it("returns true for iOS webviews when statusbar.visible is true", () => {
@@ -37,5 +40,13 @@ describe("isIosWKWebview", () => {
         }
       }
     }
+  });
+
+  it("uses window.statusbar.visible when statusBarVisible is not provided", () => {
+    Object.defineProperty(window, "statusbar", {
+      value: { visible: true },
+      configurable: true,
+    });
+    expect(isIosWKWebview(AGENTS.iPhoneWebview)).toBe(true);
   });
 });

--- a/src/__tests__/unit/is-ios.ts
+++ b/src/__tests__/unit/is-ios.ts
@@ -1,4 +1,5 @@
 import isIos = require("../../is-ios");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
@@ -9,6 +10,8 @@ const DOCUMENT_OBJECT = {
 };
 
 describe("isIos", () => {
+  restoreWindow();
+
   it("returns true for an iPad version lower than iPad OS v13", () => {
     expect(isIos(AGENTS.iPad3_2Safari)).toBe(true);
     expect(isIos(AGENTS.iPad5_1Safari)).toBe(true);
@@ -49,6 +52,14 @@ describe("isIos", () => {
         expect(isIos(ua)).toBe(false);
       }
     }
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.iPhone_9_3_1Safari,
+      configurable: true,
+    });
+    expect(isIos()).toBe(true);
   });
 
   it("return false for for iPad OS v13 when passing false for checkiPadOS", () => {

--- a/src/__tests__/unit/is-ipados.ts
+++ b/src/__tests__/unit/is-ipados.ts
@@ -1,4 +1,5 @@
 import isIpadOS = require("../../is-ipados");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
@@ -11,6 +12,8 @@ const DOCUMENT_OBJECT = {
 const DOCUMENT_OBJECT_EMPTY = {};
 
 describe("isIpadOS", () => {
+  restoreWindow();
+
   it("returns true for an iPad", () => {
     expect(isIpadOS(AGENTS.iPad3_2Safari, DOCUMENT_OBJECT)).toBe(true);
     expect(isIpadOS(AGENTS.iPad5_1Safari, DOCUMENT_OBJECT)).toBe(true);
@@ -27,6 +30,18 @@ describe("isIpadOS", () => {
 
   it("returns true for ipad", () => {
     expect(isIpadOS(AGENTS.iPadChromeLowercase, DOCUMENT_OBJECT)).toBe(true);
+  });
+
+  it("uses window.navigator.userAgent and window.document when no arguments are provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.iPad13_Safari,
+      configurable: true,
+    });
+    Object.defineProperty(window.document, "ontouchend", {
+      value: null,
+      configurable: true,
+    });
+    expect(isIpadOS()).toBe(true);
   });
 
   it("returns false for non-iOS browsers", () => {

--- a/src/__tests__/unit/is-mobile-firefox.ts
+++ b/src/__tests__/unit/is-mobile-firefox.ts
@@ -1,10 +1,13 @@
 import isMobileFirefox = require("../../is-mobile-firefox");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isMobileFirefox", () => {
+  restoreWindow();
+
   it("returns true for iPhone Firefox", () => {
     expect(isMobileFirefox(AGENTS.iPhoneFirefox)).toBe(true);
   });
@@ -34,6 +37,14 @@ describe("isMobileFirefox", () => {
         expect(isMobileFirefox(ua)).toBe(false);
       }
     });
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.androidPhoneFirefox,
+      configurable: true,
+    });
+    expect(isMobileFirefox()).toBe(true);
   });
 
   it("returns false for all other browsers", () => {

--- a/src/__tests__/unit/is-opera.ts
+++ b/src/__tests__/unit/is-opera.ts
@@ -1,10 +1,13 @@
 import isOpera = require("../../is-opera");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isOpera", () => {
+  restoreWindow();
+
   it("returns true for android Opera", () => {
     expect(isOpera(AGENTS.androidOpera)).toBe(true);
   });
@@ -23,6 +26,14 @@ describe("isOpera", () => {
 
   it("returns true for windows Opera", () => {
     expect(isOpera(AGENTS.pcOpera)).toBe(true);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.androidOpera,
+      configurable: true,
+    });
+    expect(isOpera()).toBe(true);
   });
 
   it("returns false for all other browsers", () => {

--- a/src/__tests__/unit/is-safari.ts
+++ b/src/__tests__/unit/is-safari.ts
@@ -1,10 +1,13 @@
 import isSafari = require("../../is-safari");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isSafari", () => {
+  restoreWindow();
+
   it("returns true when desktop safari", () => {
     expect(isSafari(AGENTS.macSafari7_0_2)).toBe(true);
     expect(isSafari(AGENTS.pcSafari5_1)).toBe(true);
@@ -45,6 +48,14 @@ describe("isSafari", () => {
   it("returns false when desktop edge", () => {
     expect(isSafari(AGENTS.edge12)).toBe(false);
     expect(isSafari(AGENTS.edge13)).toBe(false);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.macSafari7_0_2,
+      configurable: true,
+    });
+    expect(isSafari()).toBe(true);
   });
 
   it("returns false for all android browsers", () => {

--- a/src/__tests__/unit/is-samsung.ts
+++ b/src/__tests__/unit/is-samsung.ts
@@ -1,10 +1,13 @@
 import isSamsungBrowser = require("../../is-samsung");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isSamsungBrowser", () => {
+  restoreWindow();
+
   it("returns true for Samsung browser", () => {
     expect(isSamsungBrowser(AGENTS.androidSamsung)).toBe(true);
   });
@@ -15,6 +18,14 @@ describe("isSamsungBrowser", () => {
 
   it("returns false for Samsung webviews", () => {
     expect(isSamsungBrowser(AGENTS.androidSamsungWebview)).toBe(false);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.androidSamsung,
+      configurable: true,
+    });
+    expect(isSamsungBrowser()).toBe(true);
   });
 
   it("returns false for all other browsers", () => {

--- a/src/__tests__/unit/is-silk.ts
+++ b/src/__tests__/unit/is-silk.ts
@@ -1,16 +1,27 @@
 import isSilk = require("../../is-silk");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("isSilk", () => {
+  restoreWindow();
+
   it("returns true for android Silk", () => {
     expect(isSilk(AGENTS.androidSilk)).toBe(true);
   });
 
   it("returns true for linux Silk", () => {
     expect(isSilk(AGENTS.linuxSilk)).toBe(true);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.androidSilk,
+      configurable: true,
+    });
+    expect(isSilk()).toBe(true);
   });
 
   it("returns false for all other browsers", () => {

--- a/src/__tests__/unit/supports-payment-request-api.ts
+++ b/src/__tests__/unit/supports-payment-request-api.ts
@@ -69,4 +69,12 @@ describe("supportsPaymentRequestApi", () => {
     expect(supportsPaymentRequestApi(AGENTS.androidPhoneChrome)).toBe(false);
     expect(supportsPaymentRequestApi(AGENTS.androidPhoneChrome_60)).toBe(false);
   });
+
+  it("returns false for a Chrome-identified UA without a parseable version string", () => {
+    // Covers the !match branch in isSupportedChromeVersion — a defensive path for
+    // malformed UAs that isChrome() accepts but have no "Chrome/NN." version token.
+    expect(
+      supportsPaymentRequestApi("Mozilla/5.0 Chrome Mobile Safari/537.36"),
+    ).toBe(false);
+  });
 });

--- a/src/__tests__/unit/supports-payment-request-api.ts
+++ b/src/__tests__/unit/supports-payment-request-api.ts
@@ -1,10 +1,13 @@
 import supportsPaymentRequestApi = require("../../supports-payment-request-api");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
 describe("supportsPaymentRequestApi", () => {
+  restoreWindow();
+
   beforeEach(() => {
     window.PaymentRequest = function () {
       // noop
@@ -76,5 +79,14 @@ describe("supportsPaymentRequestApi", () => {
     expect(
       supportsPaymentRequestApi("Mozilla/5.0 Chrome Mobile Safari/537.36"),
     ).toBe(false);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.pcChrome_61,
+      configurable: true,
+    });
+
+    expect(supportsPaymentRequestApi()).toBe(true);
   });
 });

--- a/src/__tests__/unit/supports-popups.ts
+++ b/src/__tests__/unit/supports-popups.ts
@@ -1,22 +1,13 @@
 import supportsPopups = require("../../supports-popups");
+import { restoreWindow } from "../helpers/restore-window";
 
 const AGENTS: {
   [key: string]: string;
 } = require("../helpers/user-agents.json");
 
-type WindowSafari = {
-  // Disabling rule here because we don't really care is on the safari object beyond 'pushNotifications'.
-  /* eslint-disable  @typescript-eslint/no-explicit-any */
-  pushNotifications: any;
-  [key: string]: any;
-};
-declare global {
-  interface Window {
-    safari?: Partial<WindowSafari>;
-  }
-}
-
 describe("supportsPopups", () => {
+  restoreWindow();
+
   it("returns false for webviews", () => {
     let key, ua;
 
@@ -74,5 +65,13 @@ describe("supportsPopups", () => {
 
   it("returns false for old unsupported Samsung browser", () => {
     expect(supportsPopups(AGENTS.androidSamsungUnsupported)).toBe(false);
+  });
+
+  it("uses window.navigator.userAgent when no argument is provided", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: AGENTS.androidPhoneChrome,
+      configurable: true,
+    });
+    expect(supportsPopups()).toBe(true);
   });
 });

--- a/src/supports-popups.ts
+++ b/src/supports-popups.ts
@@ -7,9 +7,7 @@ import isChrome = require("./is-chrome");
 import isSamsungBrowser = require("./is-samsung");
 import isDuckDuckGo = require("./is-duckduckgo");
 
-function isUnsupportedIosChrome(ua?: string): boolean {
-  ua = ua || window.navigator.userAgent;
-
+function isUnsupportedIosChrome(ua: string): boolean {
   const match = ua.match(/CriOS\/(\d+)\./);
 
   if (!match) {
@@ -21,16 +19,13 @@ function isUnsupportedIosChrome(ua?: string): boolean {
   return version < MINIMUM_SUPPORTED_CHROME_IOS_VERSION;
 }
 
-function isOperaMini(ua?: string): boolean {
-  ua = ua || window.navigator.userAgent;
-
+function isOperaMini(ua: string): boolean {
   return ua.indexOf("Opera Mini") > -1;
 }
 
-function isAndroidWebview(ua?: string): boolean {
+function isAndroidWebview(ua: string): boolean {
   const androidWebviewRegExp = /Version\/[\d.]+/i;
 
-  ua = ua || window.navigator.userAgent;
   if (isAndroid(ua)) {
     return (
       androidWebviewRegExp.test(ua) && !isOperaMini(ua) && !isDuckDuckGo(ua)


### PR DESCRIPTION
## Summary of changes

- Adds a shared `restoreWindow()` test helper that resets `window.navigator.userAgent`, `window.statusbar`, and `window.document.ontouchend` after each test, preventing mutation leakage between unit tests.
  - I decided to not make this more generic/dynamic at this time as that would make the helper more complex. Because we only juggle a few properties at the moment explicitly cleaning them up seemed the right way to go for now.
- Adds a `"uses window.navigator.userAgent when no argument is provided"` test to every detection-function unit test file, covering the no-argument default branch of each function.
  - In real-life we don't use the argument anyway. It actually feels like a bit of an anti-pattern that that approach exists. But that's a larger conversation and also not that big of a deal.
- Adds an edge-case test to `supports-payment-request-api` for a malformed Chrome UA string with no parseable version token, covering the defensive `!match` branch in `isSupportedChromeVersion`.
- Excludes `src/__tests__/helpers/*` from Jest's test runner and excludes `src/browser-detection.ts` (a pure re-export barrel with no branches) from coverage collection.
- Removes an unused local `WindowSafari` type and `declare global` block from `supports-popups.ts`.
- Removes unreachable `ua || window.navigator.userAgent` fallback branches from the private helper functions in `supports-popups.ts` (`isUnsupportedIosChrome`, `isOperaMini`, `isAndroidWebview`) — these were dead code since the public `supportsPopups` function always resolves `ua` before passing it down.

### Coverage output

```
---------------------------------|---------|----------|---------|---------|-------------------
File                             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------------------------|---------|----------|---------|---------|-------------------
All files                        |     100 |      100 |     100 |     100 |
 has-software-keyboard.ts        |     100 |      100 |     100 |     100 |
 is-android.ts                   |     100 |      100 |     100 |     100 |
 is-chrome-os.ts                 |     100 |      100 |     100 |     100 |
 is-chrome.ts                    |     100 |      100 |     100 |     100 |
 is-duckduckgo.ts                |     100 |      100 |     100 |     100 |
 is-edge.ts                      |     100 |      100 |     100 |     100 |
 is-firefox.ts                   |     100 |      100 |     100 |     100 |
 is-ie.ts                        |     100 |      100 |     100 |     100 |
 is-ie10.ts                      |     100 |      100 |     100 |     100 |
 is-ie11.ts                      |     100 |      100 |     100 |     100 |
 is-ie9.ts                       |     100 |      100 |     100 |     100 |
 is-incognito.ts                 |     100 |      100 |     100 |     100 |
 is-ios-firefox.ts               |     100 |      100 |     100 |     100 |
 is-ios-google-search-app.ts     |     100 |      100 |     100 |     100 |
 is-ios-safari.ts                |     100 |      100 |     100 |     100 |
 is-ios-uiwebview.ts             |     100 |      100 |     100 |     100 |
 is-ios-webview.ts               |     100 |      100 |     100 |     100 |
 is-ios-wkwebview.ts             |     100 |      100 |     100 |     100 |
 is-ios.ts                       |     100 |      100 |     100 |     100 |
 is-ipados.ts                    |     100 |      100 |     100 |     100 |
 is-mobile-firefox.ts            |     100 |      100 |     100 |     100 |
 is-opera.ts                     |     100 |      100 |     100 |     100 |
 is-safari.ts                    |     100 |      100 |     100 |     100 |
 is-samsung.ts                   |     100 |      100 |     100 |     100 |
 is-silk.ts                      |     100 |      100 |     100 |     100 |
 supports-payment-request-api.ts |     100 |      100 |     100 |     100 |
 supports-popups.ts              |     100 |      100 |     100 |     100 |
---------------------------------|---------|----------|---------|---------|-------------------
```

## Checklist

- [ ] ~Added a changelog entry~ N/A: no changes to public API
- [x] Relevant test coverage
- [x] Tested and confirmed flows affected by this change are functioning as expected

## Authors

@lvandenboom

### Reviewers

@braintree/team-sdk-js