### PR TITLE
ci: run integration tests in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
     open-pull-requests-limit: 3
     allow:
       - dependency-type: "development"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,11 @@ jobs:
       BROWSERSTACK_BUILD_ID: ${{ github.run_id }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version-file: .nvmrc
       - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,26 @@ permissions:
 
 jobs:
   ci:
-    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@17a3922575160e8e3ffdb7ecc76c6a3dbfd6a50a
+    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@6b7ac15369729749c24a9df0f1285addc4554a82
+
+  integration-test:
+    name: "Integration Tests (BrowserStack)"
+    runs-on: ubuntu-latest
+    # Skip for PRs from forks to avoid running BrowserStack sessions at our cost
+    # for external contributors. Fork PRs still get unit test feedback from the
+    # ci job above.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+
+    env:
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      BROWSERSTACK_BUILD_ID: ${{ github.run_id }}
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - run: npm ci
+      - run: npm run playwright

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   pr-title-check:
     name: "Validate PR title"
+    permissions:
+      pull-requests: read
     if: >-
       github.actor != 'dependabot[bot]' &&
       !contains(github.actor, '[bot]') &&

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,14 +13,15 @@ on:
           - minor
           - major
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   publish:
-    uses: braintree/web-sdk-github-actions/.github/workflows/publish.yml@main
+    uses: braintree/web-sdk-github-actions/.github/workflows/release-pipeline.yml@b33ee0708a89181769b44cc4739dca46ac53e8ce # main
     with:
       version-type: ${{ inputs.version_type }}
     secrets:
       npm-token: ${{ secrets.BRAINTREE_NPM_ACCESS_TOKEN }}
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pretest": "npm run build",
     "test": "jest",
     "start": "npx http-server . -p 8080",
-    "preplaywright": "npm run build && rm dist/browser-detection.bundle.js && npx browserify dist/browser-detection.js -o dist/browser-detection.bundle.js --standalone browserDetection",
+    "preplaywright": "npm run build && rm -f dist/browser-detection.bundle.js && npx browserify dist/browser-detection.js -o dist/browser-detection.bundle.js --standalone browserDetection",
     "postplaywright": "npm run clean:playwright",
     "playwright": "npx playwright test --config=src/__tests__/playwright/playwright.browserstack.config.ts && npm run playwright:android",
     "playwright:local": "npm run preplaywright && npx playwright test --config=src/__tests__/playwright/playwright.local.ts && npm run postplaywright",


### PR DESCRIPTION
## Summary

- Adds a BrowserStack integration test job to the CI workflow
- Bumps the pinned SHA for the shared `web-sdk-github-actions` CI workflow to `6b7ac15`
- Ran [zizmor](https://github.com/woodruffw/zizmor) against our GitHub Actions and addressed findings: pinned action SHAs, added `persist-credentials: false`, scoped permissions on the PR title check job, and added a Dependabot cooldown
- Fixed `publish.yml`: permissions block was misplaced and the workflow was pointing at a deprecated reusable workflow (`publish.yml` → `release-pipeline.yml`)
- Fixed `preplaywright` script to use `rm -f` so it doesn't fail on a clean run

## Checklist

- [ ] Added a changelog entry
- [ ] Relevant test coverage
- [ ] Tested and confirmed flows affected by this change are functioning as expected

## Authors

@lvandenboom

### Reviewers

@braintree/team-sdk-js