### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   ci:
-    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@6b7ac15369729749c24a9df0f1285addc4554a82
+    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@7a0129438dde00a728cc851ce2cab9820bb264ed  # main
 
   integration-test:
     name: "Integration Tests (BrowserStack)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   publish:
-    uses: braintree/web-sdk-github-actions/.github/workflows/release-pipeline.yml@b33ee0708a89181769b44cc4739dca46ac53e8ce # main
+    uses: braintree/web-sdk-github-actions/.github/workflows/release-pipeline.yml@7a0129438dde00a728cc851ce2cab9820bb264ed  # main
     with:
       version-type: ${{ inputs.version_type }}
     secrets:

--- a/src/__tests__/helpers/capabilities.json
+++ b/src/__tests__/helpers/capabilities.json
@@ -54,7 +54,7 @@
   ],
   "ios": [
     {
-      "deviceName": "iPhone SE 2020",
+      "deviceName": "iPhone SE 2022",
       "browserName": "safari",
       "osVersion": "16.4"
     }


### PR DESCRIPTION
## Summary

- Pins GitHub Actions and reusable workflow references to full-length commit SHAs, per GitHub's secure-use guidance for third-party actions. SHA-pinned refs carry a trailing comment with the original tag/branch for readability.
- Updates the iOS device used in integration tests because the previous one was deprecated and would fail the test suite.

## Checklist

- [ ] ~Added a changelog entry~: N/A
- [ ] ~Relevant test coverage~: N/A
- [x] Tested and confirmed flows affected by this change are functioning as expected

## Authors

> List GitHub usernames for everyone who contributed to this pull request.

@lvandenboom 

### Reviewers

@braintree/team-sdk-js