### PR TITLE
ci: add stale cleanup workflow

### DIFF
--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -10,9 +10,11 @@ permissions: {}
 
 jobs:
   stale:
-    uses: braintree/web-sdk-github-actions/.github/workflows/stale-cleanup.yml@7a0129438dde00a728cc851ce2cab9820bb264ed
+    uses: braintree/web-sdk-github-actions/.github/workflows/stale-cleanup.yml@cf4b40ff4b46c96aadbfae38806b8de404a98cb3
     permissions:
       actions: write
       issues: write
       pull-requests: write
       contents: write
+    with:
+      start-date: "2026-06-01T00:00:00Z"

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -1,0 +1,18 @@
+name: "Stale Cleanup"
+
+on:
+  schedule:
+    # Runs at midnight UTC every Wednesday
+    - cron: "0 0 * * 3"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    uses: braintree/web-sdk-github-actions/.github/workflows/stale-cleanup.yml@7a0129438dde00a728cc851ce2cab9820bb264ed
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
+      contents: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,19 @@ Clone this repo, then install the project's dependencies:
 npm install
 ```
 
+## Branch and PR Lifecycle
+
+To keep the repository healthy, an automated workflow runs weekly:
+
+- **Branches**: flagged after 21 days of inactivity; deleted 7 days later if
+  still inactive. To keep a branch, add new commits or remove the bot's comment.
+- **Pull requests**: commented on after 14 days of inactivity; closed 7 days
+  later if still inactive. Closed PRs can be reopened at any time.
+- **Issues**: commented on after 14 days of inactivity; closed 7 days later if
+  still inactive.
+
+You can open a fresh PR or issue at any time if automated cleanup closes yours.
+
 ## Tests
 
 ```


### PR DESCRIPTION
## Summary

- Adds a `Stale Cleanup` workflow that runs on a weekly schedule (Wednesdays 00:00 UTC)
- Ignores existing issues and pull requests created before 2026-06-01
- Documents the branch and PR lifecycle policy in `CONTRIBUTING.md`

## Checklist

- [ ] ~Added a changelog entry~: N/A
- [ ] ~Relevant test coverage~: N/A
- [ ] ~Tested and confirmed flows affected by this change are functioning as expected~: must be tested after merge (already verified similar change on asset-loader).

## Authors

@lvandenboom

## Reviewers

@braintree/team-sdk-js